### PR TITLE
Design solution for using Kubernetes QoS

### DIFF
--- a/predictable_demands/quality_of_service/ReadMe.md
+++ b/predictable_demands/quality_of_service/ReadMe.md
@@ -1,0 +1,21 @@
+## Quality of Service
+
+Based on requests/limits provided for a pod, kubernetes platform will offer a specific Quality of Service(QoS)
+
+#### Best Effort
+Pods which do not have any `requests` or `limits` set for it's containers. These are known as the lowest priority pods and will be the first to be terminated by `kubelet` , if the node is under pressure due to resource crunch.
+
+
+#### Burstable
+Pods which have both `requests` and `limits` defined, however the values are not equal. Usually, the limits will be larger than requests, which means that the pod can consume more resources(when available) upto it's limit. However, if the node is under severe resource pressure, these pods will be the first to be terminated by `kubelet`, if no `Best effort` pods remain
+
+#### Guaranteed
+Pods which have equal values for `requests` and `limits`. There are highest priority pods and are not to be termintated before `Best effort` and `Burstable` pods.
+
+### Verify QoS
+ Apply all the resource files in the directory and run the following command:
+
+`kubectl get pods -o=jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.qosClass}{"\n"}{end}'`
+
+
+

--- a/predictable_demands/quality_of_service/best_effort.yml
+++ b/predictable_demands/quality_of_service/best_effort.yml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: best-effort
+  name: best-effort
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: best-effort
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: best-effort
+    spec:
+      containers:
+      - image: nginx:1.23
+        name: nginx
+        ports:
+        - containerPort: 80
+        resources: {}

--- a/predictable_demands/quality_of_service/burstable.yml
+++ b/predictable_demands/quality_of_service/burstable.yml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: burstable
+  name: burstable
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: burstable
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: burstable
+    spec:
+      containers:
+      - image: nginx:1.23
+        name: nginx
+        ports:
+        - containerPort: 80
+        resources: 
+          requests:
+            cpu : 100m
+            memory : 256Mi
+          limits: 
+            cpu: 200m
+            memory: 512Mi

--- a/predictable_demands/quality_of_service/guaranteed.yml
+++ b/predictable_demands/quality_of_service/guaranteed.yml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: guaranteed
+  name: guaranteed
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: guaranteed
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: guaranteed
+    spec:
+      containers:
+      - image: nginx:1.23
+        name: nginx
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 100m
+            memory: 256Mi


### PR DESCRIPTION
Kubernetes can work out and assign various different quality of service classes to your workloads. This is achieved based upon the requests/limits provided for a pod.

These classes can help separate the critical vs non critical apps in production scenarios. Ideally, critical apps should define both requests/limits to ensure of Guaranteed QoS, as they are least likely to be evicted by kubelet, during heavy resource utilization.

More info in ReadMe in the commit