### PR TITLE
TinyPR for Priority class usage

### DIFF
--- a/predictable_demands/pod_priority/ReadMe.md
+++ b/predictable_demands/pod_priority/ReadMe.md
@@ -1,0 +1,28 @@
+## Pod Priority
+Scheduler handles pods as first come , first serve basis in kubernetes. There is no guarantee that an app with high importance will get scheduled, when there is a system wide resource crunch.Pod Priority helps overcome this problem by ensuring pods with higher priority gets in front of the queue for scheduling.
+
+A Pod priority indicates the importance of a pod in relation to other pods. If a pod with higher priority cannot be scheduled, then the scheduler will try to evict lower 
+priority pods to schedule the high priority pod.
+
+Pod priority can be specified using a `PriorityClass`. Kubernetes already ships with two Priority classes, `system-cluster-critical` or `system-node-critical`(highest priority). Higher value specified in `PriorityClass` resource affects the order in which the scheduler places the pods.
+
+`Note`:  When defining priority classes for your applications, make sure that you use a value that is lower than the built-in `system-cluster-critical` priority class. By doing so, you can be sure that your applications will not evict system-critical pods. For criticial services such as logging agents, metrics server or an identiy provider  `system-cluster-critical` or another level below should be used.
+Marking a pod as `critical` does not prevent evictions, it only prevents the pod from becoming permanently unavailable.
+
+#### Scheduler and Pod Priority
+When a pod is created, the Priority Admission Controller uses the `PriorityClass` to populate the priority value for pods. Then, the scheduler sorts the pending pods queue based on priority order. If there's a resource crunch on nodes, then the scheduler can evict lower priority pods to schedule high priority ones. 
+
+#### PreemptionPolicy
+Priority class also defines a `preemptionPolicy` which defaults to `PreemptLowerPriority`. This basically results in providing scheduler the ability to terminate lower priority pods in favor of pods defined with higher `PriorityClass`. If `preemptionPolicy` is set to `Never`, pods in that PriorityClass will be non-preempting. This policy will not cause other existing pods to be evicted and pods would rather be scheduled as resources become free. 
+
+#### Effects with PodDisruptionBudget
+Pod priority can have an undesired effect on other Pods that are evicted. Kubernetes supports `PodDisruptionBudget` when preempting Pods, but respecting `PodDisruptionBudget` is only best effort(i.e. it is not guaranteed). The Scheduler first tries to find pods whose `PodDisruptionBudget` will not be violated , but if no such resources are found, then , scheduler will evict lower priority pods, even if their `PodDisruptionBudget` is violated.
+
+### Verify Pod Priority
+Apply all the files in the directory.
+Ensure 3 nodes exist in the cluster for scheduling.
+Run `kubectl get pdb`, which will display allowed disruptions on critical-apps-pdb. This means that in case of heavy resource utilization, scheduler based on priority classes may first evict a critical apps pod, as that is allowed without any violation, although the non-critical in this case may have a lower priority.
+
+
+Further Reading:
+[https://tanzu.vmware.com/developer/guides/workload-tenancy-priority-preemption/](https://tanzu.vmware.com/developer/guides/workload-tenancy-priority-preemption/)

--- a/predictable_demands/pod_priority/critical_app.yml
+++ b/predictable_demands/pod_priority/critical_app.yml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: critical-app
+  name: critical-app
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: critical-app
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: critical-app
+    spec:
+      containers:
+      - image: nginx:1.23
+        name: nginx
+        ports:
+        - containerPort: 80
+        resources: 
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 100m
+            memory: 256Mi  
+      priorityClassName: critical-apps
+status: {}

--- a/predictable_demands/pod_priority/non_critical_app.yml
+++ b/predictable_demands/pod_priority/non_critical_app.yml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: non-critical-app
+  name: non-critical-app
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: non-critical-app
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: non-critical-app
+    spec:
+      containers:
+      - image: nginx:1.23
+        name: nginx
+        ports:
+        - containerPort: 80
+        resources: 
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits: 
+            cpu: 200m
+            memory: 512Mi
+      priorityClassName: non-critical-apps
+status: {}

--- a/predictable_demands/pod_priority/pdb_critical_apps.yml
+++ b/predictable_demands/pod_priority/pdb_critical_apps.yml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: critical-apps-pdb
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: critical-app

--- a/predictable_demands/pod_priority/pdb_non_critical_apps.yml
+++ b/predictable_demands/pod_priority/pdb_non_critical_apps.yml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: non-critical-apps-pdb
+spec:
+  minAvailable: 3
+  selector:
+    matchLabels:
+      app: non-critical-app

--- a/predictable_demands/pod_priority/priority_class_evict_lower_priority.yml
+++ b/predictable_demands/pod_priority/priority_class_evict_lower_priority.yml
@@ -1,0 +1,8 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: critical-apps
+value: 2000000
+preemptionPolicy: PreemptLowerPriority
+globalDefault: false
+description: "This priority class will cause lower priority pods to be preempted."

--- a/predictable_demands/pod_priority/priority_class_no_preemption.yml
+++ b/predictable_demands/pod_priority/priority_class_no_preemption.yml
@@ -1,0 +1,8 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: non-critical-apps
+value: 1000000
+preemptionPolicy: Never
+globalDefault: false
+description: "This priority class will not cause other pods to be preempted."


### PR DESCRIPTION
Why ?
Scheduler handles pods as first come , first serve basis in kubernetes. There is no guarantee that an app with high importance will get scheduled, when there is a system wide resource crunch.Pod Priority help overcome this problem by ensuring pods with higher priority gets in front of the queue for scheduling.

What was added in this change :
- Priority class created for critical and non-critical apps
- Deployments depicting usage for priority class in pods
- Pod disruption budgets and their effects using preemptionPolicy


#### How to review
Deploy the relevant yaml files as per ReadMe and verify them. Check diffs and merge

#### Who can review
Not me , unless this is a solo project !!